### PR TITLE
Vishesh/sc 45297/GitHub build for sfin docs support or debugging (#12)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: [2.5, 2.6, 2.7]
+        ruby-version: [2.6, 2.7]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
* Remove builds for Ruby version 2.5 and add support for 2.8

* Drop support for Ruby 2.5

* Drop support for Ruby 2.5

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->